### PR TITLE
:sparkles: Add the Main Home Page and Details Page

### DIFF
--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge.xcodeproj/project.pbxproj
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		30671210283DC13D00210FAE /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3067120F283DC13D00210FAE /* HomeViewModel.swift */; };
 		30671212283DC77900210FAE /* StringUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30671211283DC77900210FAE /* StringUtils.swift */; };
 		30671214283DC89400210FAE /* CurrencyUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30671213283DC89400210FAE /* CurrencyUtils.swift */; };
+		306712182843FC5700210FAE /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 306712172843FC5700210FAE /* DetailViewController.swift */; };
+		3067121B284402E900210FAE /* DetailContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3067121A284402E900210FAE /* DetailContainerView.swift */; };
 		3080E2FA282DEB6B00584255 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3080E2F9282DEB6B00584255 /* AppDelegate.swift */; };
 		3080E2FC282DEB6B00584255 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3080E2FB282DEB6B00584255 /* SceneDelegate.swift */; };
 		3080E2FE282DEB6B00584255 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3080E2FD282DEB6B00584255 /* HomeViewController.swift */; };
@@ -41,6 +43,8 @@
 		30835AF4283C4E8D00421C1A /* HomeViewContainerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AF3283C4E8D00421C1A /* HomeViewContainerExtensions.swift */; };
 		30835AF7283C4FD200421C1A /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AF6283C4FD200421C1A /* HomeCollectionViewCell.swift */; };
 		30A205C028318B1400EDC26D /* CodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A205BF28318B1400EDC26D /* CodeView.swift */; };
+		30AB9B8728440B3C00A28464 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AB9B8628440B3C00A28464 /* UIColorExtension.swift */; };
+		30AB9B8A2844386400A28464 /* LineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AB9B892844386400A28464 /* LineView.swift */; };
 		4E2D257CE4A53FACC8873D0C /* Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B4884F8363DA07CBD98F6BF /* Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework */; };
 		DD52A6507EE2F23D735949E9 /* Pods_Hurb_iOS_ChallengeTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE4776A26021AD50F37DF6D3 /* Pods_Hurb_iOS_ChallengeTests.framework */; };
 		DDA1E1752F39FC3580D76604 /* Pods_Hurb_iOS_Challenge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8491EED7856ADE819B9EB15F /* Pods_Hurb_iOS_Challenge.framework */; };
@@ -69,6 +73,8 @@
 		3067120F283DC13D00210FAE /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		30671211283DC77900210FAE /* StringUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringUtils.swift; sourceTree = "<group>"; };
 		30671213283DC89400210FAE /* CurrencyUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyUtils.swift; sourceTree = "<group>"; };
+		306712172843FC5700210FAE /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
+		3067121A284402E900210FAE /* DetailContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailContainerView.swift; sourceTree = "<group>"; };
 		3080E2F6282DEB6B00584255 /* Hurb_iOS_Challenge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Hurb_iOS_Challenge.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3080E2F9282DEB6B00584255 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3080E2FB282DEB6B00584255 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -103,6 +109,8 @@
 		30835AF3283C4E8D00421C1A /* HomeViewContainerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewContainerExtensions.swift; sourceTree = "<group>"; };
 		30835AF6283C4FD200421C1A /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		30A205BF28318B1400EDC26D /* CodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeView.swift; sourceTree = "<group>"; };
+		30AB9B8628440B3C00A28464 /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
+		30AB9B892844386400A28464 /* LineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineView.swift; sourceTree = "<group>"; };
 		3550B1C6CD2BF9F2287753BC /* Pods-Hurb_iOS_ChallengeTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hurb_iOS_ChallengeTests.release.xcconfig"; path = "Target Support Files/Pods-Hurb_iOS_ChallengeTests/Pods-Hurb_iOS_ChallengeTests.release.xcconfig"; sourceTree = "<group>"; };
 		4DCCBEB9BFF194456F0BBC9F /* Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig"; path = "Target Support Files/Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests/Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig"; sourceTree = "<group>"; };
 		6B4884F8363DA07CBD98F6BF /* Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -162,6 +170,14 @@
 				DE4776A26021AD50F37DF6D3 /* Pods_Hurb_iOS_ChallengeTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		30671219284402DE00210FAE /* Detail */ = {
+			isa = PBXGroup;
+			children = (
+				3067121A284402E900210FAE /* DetailContainerView.swift */,
+			);
+			path = Detail;
 			sourceTree = "<group>";
 		};
 		3080E2ED282DEB6B00584255 = {
@@ -225,6 +241,7 @@
 		30835AF1283C4E2F00421C1A /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				30AB9B8628440B3C00A28464 /* UIColorExtension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -292,6 +309,7 @@
 				30835ACF283AEAD200421C1A /* MainTabBarController.swift */,
 				30835AD1283AEBA100421C1A /* LastSeenViewController.swift */,
 				30835AD3283AEBD100421C1A /* FavoritesViewController.swift */,
+				306712172843FC5700210FAE /* DetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -307,6 +325,8 @@
 		30A205BB2831897C00EDC26D /* View */ = {
 			isa = PBXGroup;
 			children = (
+				30AB9B882844385400A28464 /* Components */,
+				30671219284402DE00210FAE /* Detail */,
 				30835AF5283C4FB900421C1A /* Home */,
 			);
 			path = View;
@@ -344,6 +364,14 @@
 				30A205BF28318B1400EDC26D /* CodeView.swift */,
 			);
 			path = Helper;
+			sourceTree = "<group>";
+		};
+		30AB9B882844385400A28464 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				30AB9B892844386400A28464 /* LineView.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -599,9 +627,12 @@
 				30835AE4283AFE7500421C1A /* Price.swift in Sources */,
 				30835AEA283B002500421C1A /* FeaturedItem.swift in Sources */,
 				30835AF0283C4C5A00421C1A /* HomeContainerView.swift in Sources */,
+				30AB9B8A2844386400A28464 /* LineView.swift in Sources */,
 				30835AE0283AFE0900421C1A /* Address.swift in Sources */,
 				30835AD8283AF8F600421C1A /* Constants.swift in Sources */,
+				3067121B284402E900210FAE /* DetailContainerView.swift in Sources */,
 				30671212283DC77900210FAE /* StringUtils.swift in Sources */,
+				30AB9B8728440B3C00A28464 /* UIColorExtension.swift in Sources */,
 				30835AD0283AEAD200421C1A /* MainTabBarController.swift in Sources */,
 				30835AE8283B000D00421C1A /* Gallery.swift in Sources */,
 				3080E2FC282DEB6B00584255 /* SceneDelegate.swift in Sources */,
@@ -613,6 +644,7 @@
 				30A205C028318B1400EDC26D /* CodeView.swift in Sources */,
 				30835ADA283AFCF800421C1A /* Hotel.swift in Sources */,
 				3067120E283DBEBF00210FAE /* UIAlertController+UIViewController.swift in Sources */,
+				306712182843FC5700210FAE /* DetailViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge.xcodeproj/project.pbxproj
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge.xcodeproj/project.pbxproj
@@ -21,6 +21,18 @@
 		30835AD0283AEAD200421C1A /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835ACF283AEAD200421C1A /* MainTabBarController.swift */; };
 		30835AD2283AEBA100421C1A /* LastSeenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AD1283AEBA100421C1A /* LastSeenViewController.swift */; };
 		30835AD4283AEBD100421C1A /* FavoritesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AD3283AEBD100421C1A /* FavoritesViewController.swift */; };
+		30835AD6283AF7E600421C1A /* NetworkingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AD5283AF7E600421C1A /* NetworkingService.swift */; };
+		30835AD8283AF8F600421C1A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AD7283AF8F600421C1A /* Constants.swift */; };
+		30835ADA283AFCF800421C1A /* Hotel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AD9283AFCF800421C1A /* Hotel.swift */; };
+		30835ADC283AFD2500421C1A /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835ADB283AFD2500421C1A /* Filters.swift */; };
+		30835ADE283AFDDB00421C1A /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835ADD283AFDDB00421C1A /* Result.swift */; };
+		30835AE0283AFE0900421C1A /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835ADF283AFE0900421C1A /* Address.swift */; };
+		30835AE2283AFE2F00421C1A /* GeographicInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AE1283AFE2F00421C1A /* GeographicInformation.swift */; };
+		30835AE4283AFE7500421C1A /* Price.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AE3283AFE7400421C1A /* Price.swift */; };
+		30835AE6283AFFF500421C1A /* QuantityDescriptors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AE5283AFFF500421C1A /* QuantityDescriptors.swift */; };
+		30835AE8283B000D00421C1A /* Gallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AE7283B000D00421C1A /* Gallery.swift */; };
+		30835AEA283B002500421C1A /* FeaturedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AE9283B002500421C1A /* FeaturedItem.swift */; };
+		30835AEC283B00A000421C1A /* JSONMockedEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AEB283B00A000421C1A /* JSONMockedEnums.swift */; };
 		30A205C028318B1400EDC26D /* CodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A205BF28318B1400EDC26D /* CodeView.swift */; };
 		4E2D257CE4A53FACC8873D0C /* Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B4884F8363DA07CBD98F6BF /* Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework */; };
 		DD52A6507EE2F23D735949E9 /* Pods_Hurb_iOS_ChallengeTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE4776A26021AD50F37DF6D3 /* Pods_Hurb_iOS_ChallengeTests.framework */; };
@@ -64,6 +76,18 @@
 		30835ACF283AEAD200421C1A /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		30835AD1283AEBA100421C1A /* LastSeenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastSeenViewController.swift; sourceTree = "<group>"; };
 		30835AD3283AEBD100421C1A /* FavoritesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesViewController.swift; sourceTree = "<group>"; };
+		30835AD5283AF7E600421C1A /* NetworkingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingService.swift; sourceTree = "<group>"; };
+		30835AD7283AF8F600421C1A /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		30835AD9283AFCF800421C1A /* Hotel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hotel.swift; sourceTree = "<group>"; };
+		30835ADB283AFD2500421C1A /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
+		30835ADD283AFDDB00421C1A /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		30835ADF283AFE0900421C1A /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
+		30835AE1283AFE2F00421C1A /* GeographicInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeographicInformation.swift; sourceTree = "<group>"; };
+		30835AE3283AFE7400421C1A /* Price.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Price.swift; sourceTree = "<group>"; };
+		30835AE5283AFFF500421C1A /* QuantityDescriptors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityDescriptors.swift; sourceTree = "<group>"; };
+		30835AE7283B000D00421C1A /* Gallery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gallery.swift; sourceTree = "<group>"; };
+		30835AE9283B002500421C1A /* FeaturedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedItem.swift; sourceTree = "<group>"; };
+		30835AEB283B00A000421C1A /* JSONMockedEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONMockedEnums.swift; sourceTree = "<group>"; };
 		30A205BF28318B1400EDC26D /* CodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeView.swift; sourceTree = "<group>"; };
 		3550B1C6CD2BF9F2287753BC /* Pods-Hurb_iOS_ChallengeTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hurb_iOS_ChallengeTests.release.xcconfig"; path = "Target Support Files/Pods-Hurb_iOS_ChallengeTests/Pods-Hurb_iOS_ChallengeTests.release.xcconfig"; sourceTree = "<group>"; };
 		4DCCBEB9BFF194456F0BBC9F /* Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig"; path = "Target Support Files/Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests/Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -197,6 +221,7 @@
 		30A205B62831895500EDC26D /* Constants */ = {
 			isa = PBXGroup;
 			children = (
+				30835AD7283AF8F600421C1A /* Constants.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -212,6 +237,7 @@
 		30A205B82831896400EDC26D /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				30835AD5283AF7E600421C1A /* NetworkingService.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -244,6 +270,16 @@
 		30A205BC2831898300EDC26D /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				30835AD9283AFCF800421C1A /* Hotel.swift */,
+				30835ADB283AFD2500421C1A /* Filters.swift */,
+				30835ADD283AFDDB00421C1A /* Result.swift */,
+				30835ADF283AFE0900421C1A /* Address.swift */,
+				30835AE1283AFE2F00421C1A /* GeographicInformation.swift */,
+				30835AE3283AFE7400421C1A /* Price.swift */,
+				30835AE5283AFFF500421C1A /* QuantityDescriptors.swift */,
+				30835AE7283B000D00421C1A /* Gallery.swift */,
+				30835AE9283B002500421C1A /* FeaturedItem.swift */,
+				30835AEB283B00A000421C1A /* JSONMockedEnums.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -506,13 +542,25 @@
 			buildActionMask = 2147483647;
 			files = (
 				3080E2FE282DEB6B00584255 /* HomeViewController.swift in Sources */,
+				30835ADE283AFDDB00421C1A /* Result.swift in Sources */,
 				3080E2FA282DEB6B00584255 /* AppDelegate.swift in Sources */,
 				30835AD4283AEBD100421C1A /* FavoritesViewController.swift in Sources */,
+				30835AD6283AF7E600421C1A /* NetworkingService.swift in Sources */,
 				30835AD2283AEBA100421C1A /* LastSeenViewController.swift in Sources */,
+				30835AE4283AFE7500421C1A /* Price.swift in Sources */,
+				30835AEA283B002500421C1A /* FeaturedItem.swift in Sources */,
+				30835AE0283AFE0900421C1A /* Address.swift in Sources */,
+				30835AD8283AF8F600421C1A /* Constants.swift in Sources */,
 				30835AD0283AEAD200421C1A /* MainTabBarController.swift in Sources */,
+				30835AE8283B000D00421C1A /* Gallery.swift in Sources */,
 				3080E2FC282DEB6B00584255 /* SceneDelegate.swift in Sources */,
+				30835AE6283AFFF500421C1A /* QuantityDescriptors.swift in Sources */,
 				30835ACE283AE87100421C1A /* AnchorConstraints+UIView.swift in Sources */,
+				30835ADC283AFD2500421C1A /* Filters.swift in Sources */,
+				30835AE2283AFE2F00421C1A /* GeographicInformation.swift in Sources */,
+				30835AEC283B00A000421C1A /* JSONMockedEnums.swift in Sources */,
 				30A205C028318B1400EDC26D /* CodeView.swift in Sources */,
+				30835ADA283AFCF800421C1A /* Hotel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge.xcodeproj/project.pbxproj
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		30A205C028318B1400EDC26D /* CodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A205BF28318B1400EDC26D /* CodeView.swift */; };
 		30AB9B8728440B3C00A28464 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AB9B8628440B3C00A28464 /* UIColorExtension.swift */; };
 		30AB9B8A2844386400A28464 /* LineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AB9B892844386400A28464 /* LineView.swift */; };
+		30AB9B8C2846AB0200A28464 /* HotelStarsSections+Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AB9B8B2846AB0200A28464 /* HotelStarsSections+Enum.swift */; };
+		30AB9B8E2846B04600A28464 /* CollectionViewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AB9B8D2846B04600A28464 /* CollectionViewHeaderView.swift */; };
 		4E2D257CE4A53FACC8873D0C /* Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B4884F8363DA07CBD98F6BF /* Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework */; };
 		DD52A6507EE2F23D735949E9 /* Pods_Hurb_iOS_ChallengeTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE4776A26021AD50F37DF6D3 /* Pods_Hurb_iOS_ChallengeTests.framework */; };
 		DDA1E1752F39FC3580D76604 /* Pods_Hurb_iOS_Challenge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8491EED7856ADE819B9EB15F /* Pods_Hurb_iOS_Challenge.framework */; };
@@ -111,6 +113,8 @@
 		30A205BF28318B1400EDC26D /* CodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeView.swift; sourceTree = "<group>"; };
 		30AB9B8628440B3C00A28464 /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		30AB9B892844386400A28464 /* LineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineView.swift; sourceTree = "<group>"; };
+		30AB9B8B2846AB0200A28464 /* HotelStarsSections+Enum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HotelStarsSections+Enum.swift"; sourceTree = "<group>"; };
+		30AB9B8D2846B04600A28464 /* CollectionViewHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewHeaderView.swift; sourceTree = "<group>"; };
 		3550B1C6CD2BF9F2287753BC /* Pods-Hurb_iOS_ChallengeTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hurb_iOS_ChallengeTests.release.xcconfig"; path = "Target Support Files/Pods-Hurb_iOS_ChallengeTests/Pods-Hurb_iOS_ChallengeTests.release.xcconfig"; sourceTree = "<group>"; };
 		4DCCBEB9BFF194456F0BBC9F /* Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig"; path = "Target Support Files/Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests/Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig"; sourceTree = "<group>"; };
 		6B4884F8363DA07CBD98F6BF /* Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -290,6 +294,7 @@
 				3067120D283DBEBF00210FAE /* UIAlertController+UIViewController.swift */,
 				30671211283DC77900210FAE /* StringUtils.swift */,
 				30671213283DC89400210FAE /* CurrencyUtils.swift */,
+				30AB9B8B2846AB0200A28464 /* HotelStarsSections+Enum.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -370,6 +375,7 @@
 			isa = PBXGroup;
 			children = (
 				30AB9B892844386400A28464 /* LineView.swift */,
+				30AB9B8D2846B04600A28464 /* CollectionViewHeaderView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -623,6 +629,7 @@
 				30835AD6283AF7E600421C1A /* NetworkingService.swift in Sources */,
 				30671214283DC89400210FAE /* CurrencyUtils.swift in Sources */,
 				30835AF4283C4E8D00421C1A /* HomeViewContainerExtensions.swift in Sources */,
+				30AB9B8C2846AB0200A28464 /* HotelStarsSections+Enum.swift in Sources */,
 				30835AD2283AEBA100421C1A /* LastSeenViewController.swift in Sources */,
 				30835AE4283AFE7500421C1A /* Price.swift in Sources */,
 				30835AEA283B002500421C1A /* FeaturedItem.swift in Sources */,
@@ -633,6 +640,7 @@
 				3067121B284402E900210FAE /* DetailContainerView.swift in Sources */,
 				30671212283DC77900210FAE /* StringUtils.swift in Sources */,
 				30AB9B8728440B3C00A28464 /* UIColorExtension.swift in Sources */,
+				30AB9B8E2846B04600A28464 /* CollectionViewHeaderView.swift in Sources */,
 				30835AD0283AEAD200421C1A /* MainTabBarController.swift in Sources */,
 				30835AE8283B000D00421C1A /* Gallery.swift in Sources */,
 				3080E2FC282DEB6B00584255 /* SceneDelegate.swift in Sources */,

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge.xcodeproj/project.pbxproj
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3067120E283DBEBF00210FAE /* UIAlertController+UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3067120D283DBEBF00210FAE /* UIAlertController+UIViewController.swift */; };
+		30671210283DC13D00210FAE /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3067120F283DC13D00210FAE /* HomeViewModel.swift */; };
+		30671212283DC77900210FAE /* StringUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30671211283DC77900210FAE /* StringUtils.swift */; };
+		30671214283DC89400210FAE /* CurrencyUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30671213283DC89400210FAE /* CurrencyUtils.swift */; };
 		3080E2FA282DEB6B00584255 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3080E2F9282DEB6B00584255 /* AppDelegate.swift */; };
 		3080E2FC282DEB6B00584255 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3080E2FB282DEB6B00584255 /* SceneDelegate.swift */; };
 		3080E2FE282DEB6B00584255 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3080E2FD282DEB6B00584255 /* HomeViewController.swift */; };
@@ -33,6 +37,9 @@
 		30835AE8283B000D00421C1A /* Gallery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AE7283B000D00421C1A /* Gallery.swift */; };
 		30835AEA283B002500421C1A /* FeaturedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AE9283B002500421C1A /* FeaturedItem.swift */; };
 		30835AEC283B00A000421C1A /* JSONMockedEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AEB283B00A000421C1A /* JSONMockedEnums.swift */; };
+		30835AF0283C4C5A00421C1A /* HomeContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AEF283C4C5A00421C1A /* HomeContainerView.swift */; };
+		30835AF4283C4E8D00421C1A /* HomeViewContainerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AF3283C4E8D00421C1A /* HomeViewContainerExtensions.swift */; };
+		30835AF7283C4FD200421C1A /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30835AF6283C4FD200421C1A /* HomeCollectionViewCell.swift */; };
 		30A205C028318B1400EDC26D /* CodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A205BF28318B1400EDC26D /* CodeView.swift */; };
 		4E2D257CE4A53FACC8873D0C /* Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B4884F8363DA07CBD98F6BF /* Pods_Hurb_iOS_Challenge_Hurb_iOS_ChallengeUITests.framework */; };
 		DD52A6507EE2F23D735949E9 /* Pods_Hurb_iOS_ChallengeTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE4776A26021AD50F37DF6D3 /* Pods_Hurb_iOS_ChallengeTests.framework */; };
@@ -58,6 +65,10 @@
 
 /* Begin PBXFileReference section */
 		01F236C97F482D12F9042569 /* Pods-Hurb_iOS_ChallengeTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hurb_iOS_ChallengeTests.debug.xcconfig"; path = "Target Support Files/Pods-Hurb_iOS_ChallengeTests/Pods-Hurb_iOS_ChallengeTests.debug.xcconfig"; sourceTree = "<group>"; };
+		3067120D283DBEBF00210FAE /* UIAlertController+UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+UIViewController.swift"; sourceTree = "<group>"; };
+		3067120F283DC13D00210FAE /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		30671211283DC77900210FAE /* StringUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringUtils.swift; sourceTree = "<group>"; };
+		30671213283DC89400210FAE /* CurrencyUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyUtils.swift; sourceTree = "<group>"; };
 		3080E2F6282DEB6B00584255 /* Hurb_iOS_Challenge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Hurb_iOS_Challenge.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3080E2F9282DEB6B00584255 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3080E2FB282DEB6B00584255 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -88,6 +99,9 @@
 		30835AE7283B000D00421C1A /* Gallery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gallery.swift; sourceTree = "<group>"; };
 		30835AE9283B002500421C1A /* FeaturedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturedItem.swift; sourceTree = "<group>"; };
 		30835AEB283B00A000421C1A /* JSONMockedEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONMockedEnums.swift; sourceTree = "<group>"; };
+		30835AEF283C4C5A00421C1A /* HomeContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeContainerView.swift; sourceTree = "<group>"; };
+		30835AF3283C4E8D00421C1A /* HomeViewContainerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewContainerExtensions.swift; sourceTree = "<group>"; };
+		30835AF6283C4FD200421C1A /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		30A205BF28318B1400EDC26D /* CodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeView.swift; sourceTree = "<group>"; };
 		3550B1C6CD2BF9F2287753BC /* Pods-Hurb_iOS_ChallengeTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hurb_iOS_ChallengeTests.release.xcconfig"; path = "Target Support Files/Pods-Hurb_iOS_ChallengeTests/Pods-Hurb_iOS_ChallengeTests.release.xcconfig"; sourceTree = "<group>"; };
 		4DCCBEB9BFF194456F0BBC9F /* Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig"; path = "Target Support Files/Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests/Pods-Hurb_iOS_Challenge-Hurb_iOS_ChallengeUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -182,6 +196,7 @@
 				30A205BA2831897700EDC26D /* ViewModel */,
 				30A205B92831896F00EDC26D /* Controller */,
 				30A205B82831896400EDC26D /* Networking */,
+				30835AF1283C4E2F00421C1A /* Extension */,
 				30A205B72831895D00EDC26D /* Utils */,
 				30A205BE28318B0200EDC26D /* Helper */,
 				30A205B62831895500EDC26D /* Constants */,
@@ -207,6 +222,31 @@
 			path = Hurb_iOS_ChallengeUITests;
 			sourceTree = "<group>";
 		};
+		30835AF1283C4E2F00421C1A /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		30835AF2283C4E4F00421C1A /* HomeViewContainerExtensions */ = {
+			isa = PBXGroup;
+			children = (
+				30835AF3283C4E8D00421C1A /* HomeViewContainerExtensions.swift */,
+			);
+			path = HomeViewContainerExtensions;
+			sourceTree = "<group>";
+		};
+		30835AF5283C4FB900421C1A /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				30835AEF283C4C5A00421C1A /* HomeContainerView.swift */,
+				30835AF6283C4FD200421C1A /* HomeCollectionViewCell.swift */,
+				30835AF2283C4E4F00421C1A /* HomeViewContainerExtensions */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
 		30A205B52831894300EDC26D /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -230,6 +270,9 @@
 			isa = PBXGroup;
 			children = (
 				30835ACD283AE87100421C1A /* AnchorConstraints+UIView.swift */,
+				3067120D283DBEBF00210FAE /* UIAlertController+UIViewController.swift */,
+				30671211283DC77900210FAE /* StringUtils.swift */,
+				30671213283DC89400210FAE /* CurrencyUtils.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -256,6 +299,7 @@
 		30A205BA2831897700EDC26D /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				3067120F283DC13D00210FAE /* HomeViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -263,6 +307,7 @@
 		30A205BB2831897C00EDC26D /* View */ = {
 			isa = PBXGroup;
 			children = (
+				30835AF5283C4FB900421C1A /* Home */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -543,14 +588,20 @@
 			files = (
 				3080E2FE282DEB6B00584255 /* HomeViewController.swift in Sources */,
 				30835ADE283AFDDB00421C1A /* Result.swift in Sources */,
+				30835AF7283C4FD200421C1A /* HomeCollectionViewCell.swift in Sources */,
+				30671210283DC13D00210FAE /* HomeViewModel.swift in Sources */,
 				3080E2FA282DEB6B00584255 /* AppDelegate.swift in Sources */,
 				30835AD4283AEBD100421C1A /* FavoritesViewController.swift in Sources */,
 				30835AD6283AF7E600421C1A /* NetworkingService.swift in Sources */,
+				30671214283DC89400210FAE /* CurrencyUtils.swift in Sources */,
+				30835AF4283C4E8D00421C1A /* HomeViewContainerExtensions.swift in Sources */,
 				30835AD2283AEBA100421C1A /* LastSeenViewController.swift in Sources */,
 				30835AE4283AFE7500421C1A /* Price.swift in Sources */,
 				30835AEA283B002500421C1A /* FeaturedItem.swift in Sources */,
+				30835AF0283C4C5A00421C1A /* HomeContainerView.swift in Sources */,
 				30835AE0283AFE0900421C1A /* Address.swift in Sources */,
 				30835AD8283AF8F600421C1A /* Constants.swift in Sources */,
+				30671212283DC77900210FAE /* StringUtils.swift in Sources */,
 				30835AD0283AEAD200421C1A /* MainTabBarController.swift in Sources */,
 				30835AE8283B000D00421C1A /* Gallery.swift in Sources */,
 				3080E2FC282DEB6B00584255 /* SceneDelegate.swift in Sources */,
@@ -561,6 +612,7 @@
 				30835AEC283B00A000421C1A /* JSONMockedEnums.swift in Sources */,
 				30A205C028318B1400EDC26D /* CodeView.swift in Sources */,
 				30835ADA283AFCF800421C1A /* Hotel.swift in Sources */,
+				3067120E283DBEBF00210FAE /* UIAlertController+UIViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Constants/Constants.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Constants/Constants.swift
@@ -18,7 +18,11 @@ struct Constants {
     
     // MARK: - HomeCollectionView Constraints
     struct HomeCollectionViewConstraints {
-        static let HOME_COLLECTIONVIEW_DIMENTIONS_WITH_PADDING = CGSize(width: UIScreen.main.bounds.width - 32, height: 300)
+        static let HOME_COLLECTIONVIEW_DIMENTIONS_SIZE_WITH_PADDING = CGSize(width: UIScreen.main.bounds.width - 32, height: 330)
+    }
+    
+    struct DetailContainerViewConstraints {
+        static let DETAIL_IMAGES_DIMENTIONS_WITH_PADDING = CGSize(width: UIScreen.main.bounds.width, height: 400)
     }
     
     // MARK: - UIAlerts Messages

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Constants/Constants.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Constants/Constants.swift
@@ -1,0 +1,18 @@
+//
+//  Constants.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+
+
+struct Constants {
+    // MARK: - JSON Files Names Constant
+    struct JSONFilesNames {
+        static let HOTEL_JSON_FILE_NAME = "hotel"
+        static let PACKAGE_JSON_FILE_NAME = "package"
+        static let JSON_TYPE = "json"
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Constants/Constants.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Constants/Constants.swift
@@ -5,7 +5,7 @@
 //  Created by Gáudio Ney on 22/05/22.
 //
 
-import Foundation
+import UIKit
 
 
 struct Constants {
@@ -14,5 +14,15 @@ struct Constants {
         static let HOTEL_JSON_FILE_NAME = "hotel"
         static let PACKAGE_JSON_FILE_NAME = "package"
         static let JSON_TYPE = "json"
+    }
+    
+    // MARK: - HomeCollectionView Constraints
+    struct HomeCollectionViewConstraints {
+        static let HOME_COLLECTIONVIEW_DIMENTIONS_WITH_PADDING = CGSize(width: UIScreen.main.bounds.width - 32, height: 300)
+    }
+    
+    // MARK: - UIAlerts Messages
+    struct UIAlertsMessages {
+        static let SERVICE_ERROR_MESSAGE_TITLE = "Erro de Conexão"
     }
 }

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Controller/DetailViewController.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Controller/DetailViewController.swift
@@ -1,0 +1,53 @@
+//
+//  DetailViewController.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 29/05/22.
+//
+
+import UIKit
+
+class DetailViewController: UIViewController {
+    
+    // MARK: - Properties    
+    var detailContainerView = DetailContainerView()
+    
+    private var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.backgroundColor = .clear
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+    
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+    }
+    
+    // MARK: - Helper Methods
+}
+
+extension DetailViewController: CodeView {
+    func buildViewHierarchy() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(detailContainerView)
+    }
+    
+    func setupConstraints() {
+        scrollView.anchor(top: view.topAnchor,
+                                  leading: view.leadingAnchor,
+                                  bottom: view.bottomAnchor,
+                                  trailling: view.trailingAnchor)
+        
+        detailContainerView.anchor(top: scrollView.topAnchor,
+                                  leading: scrollView.leadingAnchor,
+                                  bottom: scrollView.bottomAnchor,
+                                  trailling: scrollView.trailingAnchor)
+    }
+    
+    func setupAdditionalConfiguration() {
+        view.backgroundColor = .white
+        navigationItem.title = "Hotel"
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Controller/HomeViewController.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Controller/HomeViewController.swift
@@ -9,13 +9,39 @@ import UIKit
 
 class HomeViewController: UIViewController {
     // MARK: - Properties
+    private var homeContainerView = HomeContainerView()
     
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        setupView()
+        fetchHomeData()
     }
     
     // MARK: - Helper Methods
+    
+    private func fetchHomeData() {
+        NetworkingService.shared.fetchHotels { [weak self] result in
+            switch result {
+            case .success(let hotelsResult):
+                self?.homeContainerView.hotelsResult = hotelsResult
+            case .failure(let error):
+                self?.showAlert(message: error.localizedDescription, title: Constants.UIAlertsMessages.SERVICE_ERROR_MESSAGE_TITLE)
+            }
+        }
+    }
+}
+
+extension HomeViewController: CodeView {
+    func buildViewHierarchy() {
+        view.addSubview(homeContainerView)
+    }
+    
+    func setupConstraints() {
+        homeContainerView.anchor(top: view.topAnchor,
+                                  leading: view.leadingAnchor,
+                                  bottom: view.bottomAnchor,
+                                  trailling: view.trailingAnchor)
+    }
 }
 

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Controller/HomeViewController.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Controller/HomeViewController.swift
@@ -43,5 +43,9 @@ extension HomeViewController: CodeView {
                                   bottom: view.bottomAnchor,
                                   trailling: view.trailingAnchor)
     }
+    
+    func setupAdditionalConfiguration() {
+        homeContainerView.parentViewController = self
+    }
 }
 

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Controller/MainTabBarController.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Controller/MainTabBarController.swift
@@ -58,7 +58,7 @@ class MainTabBarController: UITabBarController {
         nav.navigationBar.barStyle = .default
         nav.navigationBar.isTranslucent = false
         nav.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.white]
-        nav.hidesBarsOnSwipe = true
+        nav.hidesBarsOnSwipe = false
         
         configureNavigationBar(nav: nav)
         

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Extension/UIColorExtension.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Extension/UIColorExtension.swift
@@ -1,0 +1,21 @@
+//
+//  UIColorExtension.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 29/05/22.
+//
+
+import UIKit
+
+// MARK: - UIColor
+/// Set all custom collors used.
+extension UIColor {
+    static func rgb(red: CGFloat, green: CGFloat, blue: CGFloat) -> UIColor {
+        return UIColor(red: red/255, green: green/255, blue: blue/255, alpha: 1)
+    }
+    /// Freen Cancelation Green:
+    static let freeCancelationGreen = UIColor.rgb(red: 56, green: 150, blue: 50)
+    
+    /// Hurb Main Blue:
+    static let hurbMainBlue = UIColor.rgb(red: 31, green: 96, blue: 245)
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Address.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Address.swift
@@ -1,0 +1,31 @@
+//
+//  Address.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+
+// MARK: - Address
+struct Address: Codable {
+    let city: City?
+    let country: Country?
+    let idAtlasCity, idAtlasCountry, idAtlasNeighborhood, idAtlasState: Int?
+    let idCity, idCountry, idState: Int?
+    let state: State?
+    let street, zipcode: String?
+    let geoLocation: GeoLocation?
+
+    enum CodingKeys: String, CodingKey {
+        case city, country
+        case idAtlasCity = "id_atlas_city"
+        case idAtlasCountry = "id_atlas_country"
+        case idAtlasNeighborhood = "id_atlas_neighborhood"
+        case idAtlasState = "id_atlas_state"
+        case idCity = "id_city"
+        case idCountry = "id_country"
+        case idState = "id_state"
+        case state, street, zipcode, geoLocation
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/FeaturedItem.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/FeaturedItem.swift
@@ -1,0 +1,21 @@
+//
+//  FeaturedItem.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+
+// MARK: - FeaturedItem
+struct FeaturedItem: Codable {
+    let amenities: [String]?
+    let name: String?
+    let image: String?
+    let featuredItemDescription: String?
+
+    enum CodingKeys: String, CodingKey {
+        case amenities, name, image
+        case featuredItemDescription = "description"
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Filters.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Filters.swift
@@ -1,0 +1,16 @@
+//
+//  Filters.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+
+// MARK: - Filters
+struct Filters: Codable {
+    let amenities, countries, cities: [CityElement]?
+    let prices: [PriceElement]?
+    let priceInterval: PriceInterval?
+    let productType, rooms, stars, states: [CityElement]?
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Gallery.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Gallery.swift
@@ -1,0 +1,19 @@
+//
+//  Gallery.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+
+// MARK: - Gallery
+struct Gallery: Codable {
+    let galleryDescription: String?
+    let url: String?
+
+    enum CodingKeys: String, CodingKey {
+        case galleryDescription = "description"
+        case url
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/GeographicInformation.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/GeographicInformation.swift
@@ -1,0 +1,21 @@
+//
+//  GeographicInformation.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+
+// MARK: - CityElement
+struct CityElement: Codable {
+    let term, filter: String?
+    let count: Int?
+}
+
+// MARK: - GeoLocation
+struct GeoLocation: Codable {
+    let lat, lon: Double?
+}
+
+

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Hotel.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Hotel.swift
@@ -1,0 +1,14 @@
+//
+//  Hotel.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+
+// MARK: - HotelResponse
+struct HotelReponse: Codable {
+    let filters: Filters?
+    let results: [HotelResult]?
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/JSONMockedEnums.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/JSONMockedEnums.swift
@@ -1,0 +1,51 @@
+//
+//  JSONMockedEnums.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+
+/// Hotel Enums
+
+// MARK: - AmenityCategory
+enum AmenityCategory: String, Codable {
+    case acomodação = "Acomodação"
+    case atividades = "Atividades"
+    case comidaBebida = "Comida / Bebida"
+    case comodidadesInstalaçõesParaNegócios = "Comodidades / Instalações para negócios"
+    case diversos = "Diversos"
+    case entretenimentoEServiçosParaFamílias = "Entretenimento e serviços para famílias"
+    case lojas = "Lojas"
+    case opçõesDeTransporte = "Opções de transporte"
+    case piscinaEComodidadesDeBemEstar = "Piscina e comodidades de bem-estar"
+    case serviçosDeLimpezaLavanderia = "Serviços de limpeza / Lavanderia"
+    case serviçosDeRecepção = "Serviços de recepção"
+    case áreasComuns = "Áreas comuns"
+}
+
+// MARK: - Currency
+enum Currency: String, Codable {
+    case brl = "BRL"
+}
+
+// MARK: - City
+enum City: String, Codable {
+    case gramado = "Gramado"
+}
+
+// MARK: - Country
+enum Country: String, Codable {
+    case brasil = "Brasil"
+}
+
+// MARK: - State
+enum State: String, Codable {
+    case rioGrandeDoSul = "Rio Grande do Sul"
+}
+
+// MARK: - Result Category
+enum ResultCategory: String, Codable {
+    case hotel = "hotel"
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Price.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Price.swift
@@ -1,0 +1,21 @@
+//
+//  Price.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+
+// MARK: - PriceInterval
+struct PriceInterval: Codable {
+    let min, max: Int?
+    let filterPattern: String?
+}
+
+// MARK: - PriceElement
+struct PriceElement: Codable {
+    let min, maxExclusive: Int?
+    let filter: String?
+    let count: Int?
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/QuantityDescriptors.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/QuantityDescriptors.swift
@@ -1,0 +1,13 @@
+//
+//  QuantityDescriptors.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+
+// MARK: - QuantityDescriptors
+struct QuantityDescriptors: Codable {
+    let maxChildren, maxAdults, maxFreeChildrenAge: Int?
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Result.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Model/Result.swift
@@ -1,0 +1,60 @@
+//
+//  Result.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+
+// MARK: - Result
+struct HotelResult: Codable {
+    let sku: String?
+    let isHotel: Bool?
+    let category: ResultCategory?
+    let smallDescription: String?
+    let amenities: [ResultAmenity]?
+    let id: String?
+    let price: ResultPrice?
+    let huFreeCancellation: Bool?
+    let image: String?
+    let name: String?
+    let url: String?
+    let resultDescription: String?
+    let stars: Int?
+    let gallery: [Gallery]?
+    let address: Address?
+    let tags: [String]?
+    let quantityDescriptors: QuantityDescriptors?
+    let featuredItem: FeaturedItem?
+
+    enum CodingKeys: String, CodingKey {
+        case sku, isHotel, category, smallDescription, amenities, id, price
+        case huFreeCancellation = "hu_free_cancellation"
+        case image, name, url
+        case resultDescription = "description"
+        case stars, gallery, address, tags, quantityDescriptors, featuredItem
+    }
+}
+
+// MARK: - ResultAmenity
+struct ResultAmenity: Codable {
+    let name: String?
+    let category: AmenityCategory?
+}
+
+// MARK: - ResultPrice
+struct ResultPrice: Codable {
+    let currency, currencyOriginal: Currency?
+    let currentPrice, oldPrice: Double?
+    let sku: String?
+    let originalAmountPerDay, amountPerDay, amount: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case currency
+        case currencyOriginal = "currency_original"
+        case currentPrice = "current_price"
+        case oldPrice = "old_price"
+        case sku, originalAmountPerDay, amountPerDay, amount
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Networking/NetworkingService.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Networking/NetworkingService.swift
@@ -1,0 +1,39 @@
+//
+//  NetworkingService.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 22/05/22.
+//
+
+import Foundation
+import Alamofire
+
+final class NetworkingService {
+    // MARK: - Properties
+    
+    static let shared = NetworkingService()
+    
+    private let hotelsBaseURL: URL = Bundle.main.url(forResource: Constants.JSONFilesNames.HOTEL_JSON_FILE_NAME, withExtension: Constants.JSONFilesNames.JSON_TYPE)!
+    
+    // MARK: - Helper Methods
+    func fetchHotels(completion: @escaping (Result<[HotelResult]?, Error>) -> Void) {
+        AF.request(hotelsBaseURL,
+                   method: .get,
+                   parameters: nil,
+                   encoding: URLEncoding.default,
+                   headers: nil,
+                   interceptor: nil,
+                   requestModifier: .none).response { response in ()
+            guard let data = response.data else { return }
+            do {
+                let hotelsResponse = try JSONDecoder().decode(HotelReponse.self, from: data)
+                let hotelResult = hotelsResponse.results
+                completion(.success(hotelResult))
+            }
+            catch {
+                print(error.localizedDescription)
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Utils/AnchorConstraints+UIView.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Utils/AnchorConstraints+UIView.swift
@@ -76,10 +76,14 @@ extension UIView {
         }
     }
     
-    func setDimensions(width: CGFloat, height: CGFloat) {
+    func setDimensions(width: CGFloat? = nil, height: CGFloat? = nil) {
         translatesAutoresizingMaskIntoConstraints = false
-        widthAnchor.constraint(equalToConstant: width).isActive = true
-        heightAnchor.constraint(equalToConstant: height).isActive = true
+        if let width = width {
+            widthAnchor.constraint(equalToConstant: width).isActive = true
+        }
+        if let height = height {
+            heightAnchor.constraint(equalToConstant: height).isActive = true
+        }
     }
     
     func addConstraintsToFillView(_ view: UIView) {

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Utils/CurrencyUtils.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Utils/CurrencyUtils.swift
@@ -1,0 +1,18 @@
+//
+//  CurrencyUtils.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 24/05/22.
+//
+
+import UIKit
+
+class CurrencyUtils {
+    class func formatPrice(price: Double) -> String {
+        let currencyFormatter = NumberFormatter()
+        currencyFormatter.usesGroupingSeparator = true
+        currencyFormatter.numberStyle = .currency
+        currencyFormatter.locale = Locale(identifier: "pt_BR")
+        return currencyFormatter.string(from: NSNumber(value: price))!
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Utils/HotelStarsSections+Enum.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Utils/HotelStarsSections+Enum.swift
@@ -1,0 +1,59 @@
+//
+//  HotelStarsSections+Enum.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 31/05/22.
+//
+
+import Foundation
+
+enum StarsForSection: Int {
+    typealias rawValue = String
+    
+    case fiveStars, fourStars, threeStars, twoStars, oneStar
+    
+    init?(rawValue: Int){
+            switch rawValue {
+            case 0 : self = .fiveStars
+            case 1 : self = .fourStars
+            case 2 : self = .threeStars
+            case 3 : self = .twoStars
+            case 4 : self = .oneStar
+            default : return nil
+            }
+        }
+    
+    static let identifiers = [
+        fiveStars:     "5 Estrelas",
+        fourStars:     "4 Estrelas",
+        threeStars:    "3 Estrelas",
+        twoStars:      "2 Estrelas",
+        oneStar:       "1 Estrela"
+    ]
+    
+    static let sectionHeaders = [
+        fiveStars:     NSLocalizedString("🏨 Hotéis 5 Estrelas", comment: "Primeira Sessão"),
+        fourStars:     NSLocalizedString("🏨 Hotéis 4 Estrelas", comment: "Segunda Sessão"),
+        threeStars:    NSLocalizedString("🏨 Hotéis 3 Estrelas", comment: "Terceira Sessão"),
+        twoStars:      NSLocalizedString("🏨 Hotéis 2 Estrelas", comment: "Quarta Sessão"),
+        oneStar:       NSLocalizedString("🏨 Hotéis 1 Estrela", comment: "Quinta Sesssão")
+    ]
+    
+    static var count:Int { return 5 }
+    
+    func identifier() -> String {
+        if let id = StarsForSection.identifiers[self] {
+            return id
+        } else {
+            return "undefined"
+        }
+    }
+    
+    func headerTitle() -> String? {
+        if let string = StarsForSection.sectionHeaders[self] {
+            return string
+        } else {
+            return nil
+        }
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Utils/StringUtils.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Utils/StringUtils.swift
@@ -1,0 +1,16 @@
+//
+//  StringUtils.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 24/05/22.
+//
+
+import Foundation
+
+extension String {
+    /// Function that set the first letter of the string to uppercased style.
+    /// - Returns: String.
+    func capitalizedFirstLetter() -> String {
+        return self.prefix(1).uppercased() + self.lowercased().dropFirst()
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Utils/UIAlertController+UIViewController.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/Utils/UIAlertController+UIViewController.swift
@@ -1,0 +1,22 @@
+//
+//  AlertUtils+UIAlertController.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 24/05/22.
+//
+
+import UIKit
+
+extension UIViewController {
+    func showAlert(message: String, title: String? = nil, completionHandler: (() -> ())? = nil) {
+        let alert = UIAlertController(title: message, message: description, preferredStyle: .alert)
+        
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { (_) in
+            if completionHandler == nil {
+                return
+            }
+            completionHandler!()
+        }))
+        self.present(alert, animated: true, completion: nil)
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Components/CollectionViewHeaderView.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Components/CollectionViewHeaderView.swift
@@ -1,0 +1,64 @@
+//
+//  CollectionViewHeaderView.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 31/05/22.
+//
+
+import UIKit
+
+class CollectionViewHeaderView: UICollectionReusableView {
+    // MARK: - Properties 
+    lazy var headerDividingLine = LineView()
+    
+    private var headerDividingLine2 = LineView()
+    
+    lazy var sectionHeaderLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        label.textColor = .black
+        label.textAlignment = .left
+        return label
+    }()
+    
+    lazy var stackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [headerDividingLine,
+                                                   sectionHeaderLabel,
+                                                   headerDividingLine2])
+        stack.axis = .vertical
+        stack.spacing = 8
+        stack.alignment = .leading
+        stack.distribution = .fillProportionally
+        return stack
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .lightGray
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension CollectionViewHeaderView: CodeView {
+    func buildViewHierarchy() {
+        addSubview(stackView)
+    }
+    
+    func setupConstraints() {
+        stackView.anchor(top: topAnchor,
+                         leading: leadingAnchor,
+                         bottom: bottomAnchor,
+                         trailling: trailingAnchor,
+                         paddingLeading: 16,
+                         paddingBottom: 8,
+                         paddingTrailling: 16)
+    }
+    
+    func setupAdditionalConfiguration() {
+        backgroundColor = .white
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Components/LineView.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Components/LineView.swift
@@ -1,0 +1,21 @@
+//
+//  LineView.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 29/05/22.
+//
+
+import UIKit
+
+class LineView: UIView {
+    // MARK: - Lifecycle
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .lightGray
+        setDimensions(width: Constants.HomeCollectionViewConstraints.HOME_COLLECTIONVIEW_DIMENTIONS_SIZE_WITH_PADDING.width, height: 0.5)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Detail/DetailContainerView.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Detail/DetailContainerView.swift
@@ -1,0 +1,308 @@
+//
+//  DetailContainerView.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 29/05/22.
+//
+
+import UIKit
+
+class DetailContainerView: UIView {
+    // MARK: - Properties
+    var hotelsResult: HotelResult? {
+        didSet {
+            configureContainter()
+        }
+    }
+    
+    /// State Control - Boolean variables.
+    private var isFullDescriptionShown = false
+    
+    /// Views.
+    
+    private var imageStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.clipsToBounds = true
+        return stackView
+    }()
+    
+    lazy var imageScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.setDimensions(width: Constants.DetailContainerViewConstraints.DETAIL_IMAGES_DIMENTIONS_WITH_PADDING.width,
+                                 height: Constants.DetailContainerViewConstraints.DETAIL_IMAGES_DIMENTIONS_WITH_PADDING.height)
+        scrollView.isPagingEnabled = true
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.delegate = self
+        scrollView.backgroundColor = .clear
+        scrollView.bounces = false
+        return scrollView
+    }()
+    
+    private var imagePageControl: UIPageControl = {
+        let pageControl = UIPageControl()
+        pageControl.pageIndicatorTintColor = .lightGray
+        pageControl.currentPageIndicatorTintColor = .white
+        pageControl.setDimensions(height: 6)
+        return pageControl
+    }()
+    
+    private var hotelNameLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 2
+        label.textAlignment = .left
+        label.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
+        label.textColor = .black
+        return label
+    }()
+    
+    private var hotelLocationLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 2
+        label.textAlignment = .left
+        label.textColor = .black
+        return label
+    }()
+    
+    private var originalPriceLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        label.textAlignment = .left
+        label.textColor = .black
+        return label
+    }()
+    
+    private var finalPriceLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        label.textAlignment = .left
+        label.textColor = .black
+        return label
+    }()
+    
+    private var freeCancelationLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        label.textAlignment = .left
+        label.textColor = .freeCancelationGreen
+        label.font = UIFont.systemFont(ofSize: 13, weight: .regular)
+        return label
+    }()
+    
+    private var hotelAmenitiesLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = .max
+        label.textAlignment = .left
+        label.textColor = .black
+        return label
+    }()
+    
+    private var starLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.textAlignment = .left
+        label.textColor = .black
+        label.font = UIFont.systemFont(ofSize: 13, weight: .light)
+        return label
+    }()
+    
+    lazy var smallDescriptionLabel: UILabel = {
+        let label = UILabel()
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(showMore(tapGesture:)))
+        label.numberOfLines = .max
+        label.textAlignment = .left
+        label.textColor = .black
+        label.isUserInteractionEnabled = true
+        label.addGestureRecognizer(tapGesture)
+        return label
+    }()
+    
+    private var fullDescriptionLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = .max
+        label.textAlignment = .left
+        label.textColor = .gray
+        label.font = UIFont.systemFont(ofSize: 13, weight: .light)
+        label.isHidden = true
+        return label
+    }()
+    
+    private var lineSpacing = LineView()
+    private var lineSpacing2 = LineView()
+    private var lineSpacing3 = LineView()
+    
+    /// Stacks.
+    lazy var hotelDescriptionsStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [smallDescriptionLabel, fullDescriptionLabel])
+        stack.axis = .vertical
+        stack.alignment = .leading
+        stack.distribution = .fillProportionally
+        stack.spacing = 16
+        return stack
+    }()
+    
+    // MARK: - Lifecycle
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Helper Methods
+    private func configureContainter() {
+        guard let hotelsResult = hotelsResult else { return }
+        let viewModel = HomeViewModel()
+        viewModel.hotelResult = hotelsResult
+        
+        hotelNameLabel.text = viewModel.hotelDetailName
+        hotelLocationLabel.attributedText = viewModel.hotelDetailLocation
+        finalPriceLabel.attributedText = viewModel.hotelFinalPriceText
+        starLabel.text = viewModel.hotelStars
+        freeCancelationLabel.text = viewModel.freeCancelingText
+        hotelAmenitiesLabel.attributedText = viewModel.hotelDetailAmenitiesText
+        smallDescriptionLabel.attributedText = viewModel.hotelDetailSmallDescription
+        fullDescriptionLabel.text = viewModel.hotelDetailFullDescription
+        
+        /// Configure `ScrollView` and `PageControl`.
+        imagePageControl.numberOfPages = viewModel.hotelsImage.count
+        imagePageControl.currentPage = 0
+        
+        for imageURL in viewModel.hotelsImage {
+            let url = URL(string: imageURL)
+            let imageView = UIImageView()
+            imageView.kf.setImage(with: url)
+            imageView.contentMode = .scaleAspectFill
+            imageView.setDimensions(width: Constants.DetailContainerViewConstraints.DETAIL_IMAGES_DIMENTIONS_WITH_PADDING.width,
+                                    height: Constants.DetailContainerViewConstraints.DETAIL_IMAGES_DIMENTIONS_WITH_PADDING.height)
+            imageView.clipsToBounds = true
+            if imageView.image == nil {
+                imageView.image = UIImage(systemName: "xmark.rectangle.fill")
+                imageView.tintColor = .darkGray
+            }
+            imageStackView.addArrangedSubview(imageView)
+        }
+        
+        imageScrollView.contentSize = CGSize(width: imageScrollView.contentSize.width * CGFloat(viewModel.hotelsImage.count),
+                                             height: imageScrollView.contentSize.height)
+        
+        /// Configure `FreeCancelationLabel`.
+        if freeCancelationLabel.text == "" {
+            freeCancelationLabel.isHidden = true
+        }
+    }
+    
+    // MARK: - Selectors
+    @objc func showMore(tapGesture: UITapGestureRecognizer) {
+        isFullDescriptionShown.toggle()
+        fullDescriptionLabel.isHidden = isFullDescriptionShown ? false : true
+    }
+}
+
+extension DetailContainerView: CodeView {
+    func buildViewHierarchy() {
+        addSubview(imageScrollView)
+        imageScrollView.addSubview(imageStackView)
+        addSubview(imagePageControl)
+        addSubview(hotelNameLabel)
+        addSubview(starLabel)
+        addSubview(hotelLocationLabel)
+        addSubview(finalPriceLabel)
+        addSubview(hotelAmenitiesLabel)
+        addSubview(freeCancelationLabel)
+        addSubview(hotelDescriptionsStackView)
+        addSubview(lineSpacing)
+        addSubview(lineSpacing2)
+        addSubview(lineSpacing3)
+    }
+    
+    func setupConstraints() {
+        imageScrollView.anchor(top: topAnchor,
+                               leading: leadingAnchor,
+                               trailling: trailingAnchor)
+        
+        imagePageControl.centerX(inView: imageScrollView,
+                                 topAnchor: imageScrollView.bottomAnchor,
+                                 paddingTop: -16)
+        
+        hotelNameLabel.anchor(top: imageScrollView.bottomAnchor,
+                              leading: leadingAnchor,
+                              trailling: trailingAnchor,
+                              paddingTop: 16,
+                              paddingLeading: 16,
+                              paddingTrailling: 16)
+        
+        starLabel.anchor(top: hotelNameLabel.bottomAnchor,
+                         leading: leadingAnchor,
+                         paddingTop: 8,
+                         paddingLeading: 16, width: 45)
+        
+        hotelLocationLabel.anchor(top: starLabel.topAnchor,
+                                  leading: starLabel.trailingAnchor,
+                                  trailling: trailingAnchor,
+                                  paddingTrailling: 16)
+        
+        lineSpacing.anchor(top: hotelLocationLabel.bottomAnchor,
+                           leading: leadingAnchor,
+                           trailling: trailingAnchor,
+                           paddingTop: 16,
+                           paddingLeading: 16,
+                           paddingTrailling: 16)
+        
+        hotelAmenitiesLabel.anchor(top: lineSpacing.bottomAnchor,
+                                   leading: leadingAnchor,
+                                   trailling: trailingAnchor,
+                                   paddingTop: 16,
+                                   paddingLeading: 16,
+                                   paddingTrailling: 16)
+        
+        lineSpacing2.anchor(top: hotelAmenitiesLabel.bottomAnchor,
+                           leading: leadingAnchor,
+                           trailling: trailingAnchor,
+                           paddingTop: 16,
+                           paddingLeading: 16,
+                           paddingTrailling: 16)
+        
+        finalPriceLabel.anchor(top: lineSpacing2.bottomAnchor,
+                               leading: leadingAnchor,
+                               trailling: trailingAnchor,
+                               paddingTop: 16,
+                               paddingLeading: 16,
+                               paddingTrailling: 16)
+        
+        freeCancelationLabel.anchor(top: finalPriceLabel.bottomAnchor,
+                                    leading: leadingAnchor,
+                                    trailling: trailingAnchor,
+                                    paddingTop: 8,
+                                    paddingLeading: 16,
+                                    paddingTrailling: 16)
+        
+        lineSpacing3.anchor(top: freeCancelationLabel.bottomAnchor,
+                           leading: leadingAnchor,
+                           trailling: trailingAnchor,
+                           paddingTop: 16,
+                           paddingLeading: 16,
+                           paddingTrailling: 16)
+
+        
+        hotelDescriptionsStackView.anchor(top: lineSpacing3.bottomAnchor,
+                                          leading: leadingAnchor,
+                                          bottom: bottomAnchor,
+                                          trailling: trailingAnchor,
+                                          paddingTop: 16,
+                                          paddingLeading: 16,
+                                          paddingBottom: 16,
+                                          paddingTrailling: 16)
+        
+        imageStackView.addConstraintsToFillView(imageScrollView)
+    }
+}
+
+extension DetailContainerView: UIScrollViewDelegate {
+    /// Set the current page of `PageControl` based on the `ScrollView` lenth.
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        imagePageControl.currentPage = Int(scrollView.contentOffset.x / (scrollView.frame.width))
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Detail/DetailContainerView.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Detail/DetailContainerView.swift
@@ -111,6 +111,7 @@ class DetailContainerView: UIView {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(showMore(tapGesture:)))
         label.numberOfLines = .max
         label.textAlignment = .left
+        label.lineBreakMode = .byWordWrapping
         label.textColor = .black
         label.isUserInteractionEnabled = true
         label.addGestureRecognizer(tapGesture)
@@ -127,13 +128,22 @@ class DetailContainerView: UIView {
         return label
     }()
     
+    lazy var showHideFullDescriptionButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle(" ‣ Ver mais ", for: .normal)
+        button.titleLabel?.tintColor = .hurbMainBlue
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .semibold)
+        button.addTarget(self, action: #selector(showMore), for: .touchUpInside)
+        return button
+    }()
+    
     private var lineSpacing = LineView()
     private var lineSpacing2 = LineView()
     private var lineSpacing3 = LineView()
     
     /// Stacks.
     lazy var hotelDescriptionsStackView: UIStackView = {
-        let stack = UIStackView(arrangedSubviews: [smallDescriptionLabel, fullDescriptionLabel])
+        let stack = UIStackView(arrangedSubviews: [smallDescriptionLabel, showHideFullDescriptionButton, fullDescriptionLabel])
         stack.axis = .vertical
         stack.alignment = .leading
         stack.distribution = .fillProportionally
@@ -198,6 +208,7 @@ class DetailContainerView: UIView {
     @objc func showMore(tapGesture: UITapGestureRecognizer) {
         isFullDescriptionShown.toggle()
         fullDescriptionLabel.isHidden = isFullDescriptionShown ? false : true
+        showHideFullDescriptionButton.setTitle(isFullDescriptionShown ? " ▴ Ver menos " : " ▾ Ver mais ", for: .normal)
     }
 }
 

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeCollectionViewCell.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeCollectionViewCell.swift
@@ -1,0 +1,198 @@
+//
+//  HomeCollectionViewCell.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 23/05/22.
+//
+
+import UIKit
+import Kingfisher
+
+class HomeCollectionViewCell: UICollectionViewCell {
+    // MARK: - Properties
+    var hotelResult: HotelResult? {
+        didSet {
+            configureCell()
+        }
+    }
+    
+    private var imageStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.clipsToBounds = true
+        return stackView
+    }()
+    
+    lazy var imageScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.setDimensions(width: Constants.HomeCollectionViewConstraints.HOME_COLLECTIONVIEW_DIMENTIONS_WITH_PADDING.width,
+                                 height: 180)
+        scrollView.isPagingEnabled = true
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.delegate = self
+        scrollView.backgroundColor = .clear
+        scrollView.bounces = false
+        scrollView.layer.cornerRadius = 8
+        scrollView.clipsToBounds = true
+        return scrollView
+    }()
+    
+    private var imagePageControl: UIPageControl = {
+        let pageControl = UIPageControl()
+        pageControl.pageIndicatorTintColor = .lightGray
+        pageControl.currentPageIndicatorTintColor = .white
+        pageControl.setDimensions(height: 6)
+        return pageControl
+    }()
+    
+    private var hotelDescriptionLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 2
+        label.textAlignment = .left
+        label.textColor = .black
+        return label
+    }()
+    
+    private var nightsLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        label.textAlignment = .left
+        label.textColor = .black
+        return label
+    }()
+    
+    private var originalPriceLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        label.textAlignment = .left
+        label.textColor = .black
+        label.font = UIFont.systemFont(ofSize: 12, weight: .light)
+        return label
+    }()
+    
+    private var finalPriceLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        label.textAlignment = .left
+        label.textColor = .black
+        return label
+    }()
+    
+    private var freeCancelationLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        label.textAlignment = .left
+        label.textColor = .green
+        label.font = UIFont.systemFont(ofSize: 13, weight: .regular)
+        return label
+    }()
+    
+    private var hotelAmenitiesLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 2
+        label.textAlignment = .left
+        label.textColor = .black
+        return label
+    }()
+    
+    // MARK: - Lifecycle
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func configureCell() {
+        guard let hotelResult = hotelResult else { return }
+        let viewModel = HomeViewModel()
+        viewModel.hotelResult = hotelResult
+        
+        hotelDescriptionLabel.attributedText = viewModel.hotelDescriptionText
+        finalPriceLabel.attributedText = viewModel.hotelFinalPriceText
+        freeCancelationLabel.text = viewModel.freeCancelingText
+        hotelAmenitiesLabel.attributedText = viewModel.hotelAmenitiesText
+        
+        /// Configure `ScrollView` and `PageControl`.
+        for imageURL in viewModel.hotelsImage {
+            let url = URL(string: imageURL)
+            let imageView = UIImageView()
+            imageView.kf.setImage(with: url)
+            imageView.contentMode = .scaleAspectFill
+            imageView.setDimensions(width: Constants.HomeCollectionViewConstraints.HOME_COLLECTIONVIEW_DIMENTIONS_WITH_PADDING.width,
+                                    height: 180)
+            imageView.clipsToBounds = true
+            if imageView.image == nil {
+                imageView.image = UIImage(systemName: "xmark.rectangle.fill")
+                imageView.tintColor = .darkGray
+            }
+            imageStackView.addArrangedSubview(imageView)
+        }
+        
+        imageScrollView.contentSize = CGSize(width: imageScrollView.contentSize.width * CGFloat(viewModel.hotelsImage.count),
+                                             height: imageScrollView.contentSize.height)
+        imagePageControl.numberOfPages = viewModel.hotelsImage.count
+        imagePageControl.currentPage = 0
+    }
+}
+
+extension HomeCollectionViewCell: CodeView {
+    func buildViewHierarchy() {
+        addSubview(imageScrollView)
+        imageScrollView.addSubview(imageStackView)
+        addSubview(imagePageControl)
+        addSubview(hotelDescriptionLabel)
+        addSubview(finalPriceLabel)
+        addSubview(hotelAmenitiesLabel)
+        addSubview(freeCancelationLabel)
+    }
+    
+    func setupConstraints() {
+        imageScrollView.anchor(top: topAnchor,
+                               leading: leadingAnchor,
+                               trailling: trailingAnchor)
+        
+        imagePageControl.centerX(inView: imageScrollView,
+                                 topAnchor: imageScrollView.bottomAnchor,
+                                 paddingTop: -16)
+        
+        hotelDescriptionLabel.anchor(top: imageScrollView.bottomAnchor,
+                                     leading: leadingAnchor,
+                                     trailling: trailingAnchor,
+                                     paddingTop: 8)
+        
+        finalPriceLabel.anchor(top: hotelDescriptionLabel.bottomAnchor,
+                               leading: leadingAnchor,
+                               trailling: trailingAnchor,
+                               paddingTop: 8)
+        
+        hotelAmenitiesLabel.anchor(top: finalPriceLabel.bottomAnchor,
+                                   leading: leadingAnchor,
+                                   trailling: trailingAnchor,
+                                   paddingTop: 8)
+        
+        freeCancelationLabel.anchor(top: hotelAmenitiesLabel.bottomAnchor,
+                                    leading: leadingAnchor,
+                                    bottom: bottomAnchor,
+                                    trailling: trailingAnchor,
+                                    paddingTop: 8)
+        
+        imageStackView.addConstraintsToFillView(imageScrollView)
+    }
+    
+    func setupAdditionalConfiguration() {
+        backgroundColor = .white
+        clipsToBounds = true
+    }
+}
+
+extension HomeCollectionViewCell: UIScrollViewDelegate {
+    /// Set the current page of `PageControl` based on the `ScrollView` lenth.
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        imagePageControl.currentPage = Int(scrollView.contentOffset.x / (scrollView.frame.width))
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeCollectionViewCell.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeCollectionViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 import Kingfisher
 
 class HomeCollectionViewCell: UICollectionViewCell {
-    // MARK: - Properties
+    // MARK: - Properties    
     var hotelResult: HotelResult? {
         didSet {
             configureCell()
@@ -25,7 +25,7 @@ class HomeCollectionViewCell: UICollectionViewCell {
     
     lazy var imageScrollView: UIScrollView = {
         let scrollView = UIScrollView()
-        scrollView.setDimensions(width: Constants.HomeCollectionViewConstraints.HOME_COLLECTIONVIEW_DIMENTIONS_WITH_PADDING.width,
+        scrollView.setDimensions(width: Constants.HomeCollectionViewConstraints.HOME_COLLECTIONVIEW_DIMENTIONS_SIZE_WITH_PADDING.width,
                                  height: 180)
         scrollView.isPagingEnabled = true
         scrollView.showsHorizontalScrollIndicator = false
@@ -53,20 +53,11 @@ class HomeCollectionViewCell: UICollectionViewCell {
         return label
     }()
     
-    private var nightsLabel: UILabel = {
-        let label = UILabel()
-        label.numberOfLines = 1
-        label.textAlignment = .left
-        label.textColor = .black
-        return label
-    }()
-    
     private var originalPriceLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 1
         label.textAlignment = .left
         label.textColor = .black
-        label.font = UIFont.systemFont(ofSize: 12, weight: .light)
         return label
     }()
     
@@ -82,7 +73,7 @@ class HomeCollectionViewCell: UICollectionViewCell {
         let label = UILabel()
         label.numberOfLines = 1
         label.textAlignment = .left
-        label.textColor = .green
+        label.textColor = .freeCancelationGreen
         label.font = UIFont.systemFont(ofSize: 13, weight: .regular)
         return label
     }()
@@ -91,7 +82,16 @@ class HomeCollectionViewCell: UICollectionViewCell {
         let label = UILabel()
         label.numberOfLines = 2
         label.textAlignment = .left
+        label.textColor = .gray
+        return label
+    }()
+    
+    private var starLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.textAlignment = .left
         label.textColor = .black
+        label.font = UIFont.systemFont(ofSize: 13, weight: .light)
         return label
     }()
     
@@ -114,16 +114,20 @@ class HomeCollectionViewCell: UICollectionViewCell {
         
         hotelDescriptionLabel.attributedText = viewModel.hotelDescriptionText
         finalPriceLabel.attributedText = viewModel.hotelFinalPriceText
+        starLabel.text = viewModel.hotelStars
         freeCancelationLabel.text = viewModel.freeCancelingText
         hotelAmenitiesLabel.attributedText = viewModel.hotelAmenitiesText
         
         /// Configure `ScrollView` and `PageControl`.
+        imagePageControl.numberOfPages = viewModel.hotelsImage.count
+        imagePageControl.currentPage = 0
+        
         for imageURL in viewModel.hotelsImage {
             let url = URL(string: imageURL)
             let imageView = UIImageView()
             imageView.kf.setImage(with: url)
             imageView.contentMode = .scaleAspectFill
-            imageView.setDimensions(width: Constants.HomeCollectionViewConstraints.HOME_COLLECTIONVIEW_DIMENTIONS_WITH_PADDING.width,
+            imageView.setDimensions(width: Constants.HomeCollectionViewConstraints.HOME_COLLECTIONVIEW_DIMENTIONS_SIZE_WITH_PADDING.width,
                                     height: 180)
             imageView.clipsToBounds = true
             if imageView.image == nil {
@@ -135,8 +139,11 @@ class HomeCollectionViewCell: UICollectionViewCell {
         
         imageScrollView.contentSize = CGSize(width: imageScrollView.contentSize.width * CGFloat(viewModel.hotelsImage.count),
                                              height: imageScrollView.contentSize.height)
-        imagePageControl.numberOfPages = viewModel.hotelsImage.count
-        imagePageControl.currentPage = 0
+        
+        /// Configure `FreeCancelationLabel`.
+        if freeCancelationLabel.text == "" {
+            freeCancelationLabel.isHidden = true
+        }
     }
 }
 
@@ -147,6 +154,7 @@ extension HomeCollectionViewCell: CodeView {
         addSubview(imagePageControl)
         addSubview(hotelDescriptionLabel)
         addSubview(finalPriceLabel)
+        addSubview(starLabel)
         addSubview(hotelAmenitiesLabel)
         addSubview(freeCancelationLabel)
     }
@@ -170,7 +178,12 @@ extension HomeCollectionViewCell: CodeView {
                                trailling: trailingAnchor,
                                paddingTop: 8)
         
-        hotelAmenitiesLabel.anchor(top: finalPriceLabel.bottomAnchor,
+        starLabel.anchor(top: finalPriceLabel.bottomAnchor,
+                                   leading: leadingAnchor,
+                                   trailling: trailingAnchor,
+                                   paddingTop: 8)
+        
+        hotelAmenitiesLabel.anchor(top: starLabel.bottomAnchor,
                                    leading: leadingAnchor,
                                    trailling: trailingAnchor,
                                    paddingTop: 8)

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeContainerView.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeContainerView.swift
@@ -9,6 +9,8 @@ import UIKit
 
 class HomeContainerView: UIView {
     // MARK: - Properties
+    var parentViewController: HomeViewController?
+    
     var hotelsResult: [HotelResult]? {
         didSet {
             configureContainter()
@@ -21,6 +23,7 @@ class HomeContainerView: UIView {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         layout.minimumInteritemSpacing = 8
+        layout.minimumLineSpacing = 16
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .clear

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeContainerView.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeContainerView.swift
@@ -17,7 +17,16 @@ class HomeContainerView: UIView {
         }
     }
     
+    var oneStarHotel: [HotelResult] = []
+    var twoStarHotel: [HotelResult] = []
+    var threeStarHotel: [HotelResult] = []
+    var fourStarHotel: [HotelResult] = []
+    var fiveStarHotel: [HotelResult] = []
+    
+    //let sectionTitles: [String] = ["5 Estrelas", "4 Estrelas", "3 Estrelas", "2 Estrelas", "1 Estrela"]
+    
     let reuseIdentifier = String(describing: HomeCollectionViewCell.self)
+    let headerIdentifier = "HeaderIdentifier"
     
     lazy var homeCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -26,7 +35,6 @@ class HomeContainerView: UIView {
         layout.minimumLineSpacing = 16
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = .clear
         collectionView.isUserInteractionEnabled = true
         collectionView.showsVerticalScrollIndicator = false
         collectionView.dataSource = self
@@ -46,9 +54,34 @@ class HomeContainerView: UIView {
     }
     
     // MARK: - Helper Methods
-    
     private func configureContainter() {
+        filterHotels()
         homeCollectionView.reloadData()
+    }
+    
+    // MARK: - Filter Hotels by Stars
+    private func filterHotels() {
+        guard let hotelsResult = hotelsResult else { return }
+        for hotel in hotelsResult {
+            if hotel.stars == 1 {
+                oneStarHotel.append(hotel)
+            }
+            else if hotel.stars == 2 {
+                twoStarHotel.append(hotel)
+            }
+            else if hotel.stars == 3 {
+                threeStarHotel.append(hotel)
+            }
+            else if hotel.stars == 4 {
+                fourStarHotel.append(hotel)
+            }
+            else if hotel.stars == 5 {
+                fiveStarHotel.append(hotel)
+            }
+            else {
+                return
+            }
+        }
     }
 }
 
@@ -66,7 +99,10 @@ extension HomeContainerView: CodeView {
     }
     
     func setupAdditionalConfiguration() {
+        /// Configure View.
+        backgroundColor = .white
         /// Register CollectionView Cell.
         homeCollectionView.register(HomeCollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
+        homeCollectionView.register(CollectionViewHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: headerIdentifier)
     }
 }

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeContainerView.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeContainerView.swift
@@ -1,0 +1,69 @@
+//
+//  HomeContainerView.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 23/05/22.
+//
+
+import UIKit
+
+class HomeContainerView: UIView {
+    // MARK: - Properties
+    var hotelsResult: [HotelResult]? {
+        didSet {
+            configureContainter()
+        }
+    }
+    
+    let reuseIdentifier = String(describing: HomeCollectionViewCell.self)
+    
+    lazy var homeCollectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        layout.minimumInteritemSpacing = 8
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .clear
+        collectionView.isUserInteractionEnabled = true
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.backgroundColor = .white
+        return collectionView
+    }()
+    
+    // MARK: - Lifecycle
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func configureContainter() {
+        homeCollectionView.reloadData()
+    }
+}
+
+// MARK: - CodeView
+extension HomeContainerView: CodeView {
+    func buildViewHierarchy() {
+        addSubview(homeCollectionView)
+    }
+    
+    func setupConstraints() {
+        homeCollectionView.anchor(top: topAnchor,
+                                  leading: leadingAnchor,
+                                  bottom: bottomAnchor,
+                                  trailling: trailingAnchor)
+    }
+    
+    func setupAdditionalConfiguration() {
+        /// Register CollectionView Cell.
+        homeCollectionView.register(HomeCollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeViewContainerExtensions/HomeViewContainerExtensions.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeViewContainerExtensions/HomeViewContainerExtensions.swift
@@ -1,0 +1,38 @@
+//
+//  HomeViewContainerExtensions.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 23/05/22.
+//
+
+import UIKit
+
+// MARK: - UICollectionViewDataSource
+extension HomeContainerView: UICollectionViewDataSource {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        hotelsResult?.count ?? 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as! HomeCollectionViewCell
+        let hotel = hotelsResult?[indexPath.row]
+        let viewModel = HomeViewModel()
+        viewModel.hotelResult = hotel
+        cell.hotelResult = hotel
+        return cell
+    }
+}
+
+extension HomeContainerView: UICollectionViewDelegate {
+    
+}
+
+extension HomeContainerView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return Constants.HomeCollectionViewConstraints.HOME_COLLECTIONVIEW_DIMENTIONS_WITH_PADDING
+    }
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeViewContainerExtensions/HomeViewContainerExtensions.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeViewContainerExtensions/HomeViewContainerExtensions.swift
@@ -28,11 +28,18 @@ extension HomeContainerView: UICollectionViewDataSource {
 }
 
 extension HomeContainerView: UICollectionViewDelegate {
-    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        DispatchQueue.main.async { [weak self] in
+            let viewController = DetailViewController()
+            guard let hotelsResult = self?.hotelsResult else { return }
+            viewController.detailContainerView.hotelsResult  = hotelsResult[indexPath.row]
+            self?.parentViewController?.navigationController?.pushViewController(viewController, animated: true)
+        }
+    }
 }
 
 extension HomeContainerView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return Constants.HomeCollectionViewConstraints.HOME_COLLECTIONVIEW_DIMENTIONS_WITH_PADDING
+        return Constants.HomeCollectionViewConstraints.HOME_COLLECTIONVIEW_DIMENTIONS_SIZE_WITH_PADDING
     }
 }

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeViewContainerExtensions/HomeViewContainerExtensions.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/View/Home/HomeViewContainerExtensions/HomeViewContainerExtensions.swift
@@ -10,19 +10,110 @@ import UIKit
 // MARK: - UICollectionViewDataSource
 extension HomeContainerView: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return 1
+        return StarsForSection.count
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        hotelsResult?.count ?? 0
+        let section: StarsForSection = StarsForSection(rawValue: section)!
+        switch section {
+        case .fiveStars:
+            if fiveStarHotel.count > 0 {
+                return fiveStarHotel.count
+            }
+            else { return 0 }
+        case .fourStars:
+            if fourStarHotel.count > 0 {
+                return fourStarHotel.count
+            }
+            else { return 0 }
+        case .threeStars:
+            if threeStarHotel.count > 0 {
+                return threeStarHotel.count
+            }
+            else { return 0 }
+        case .twoStars:
+            if twoStarHotel.count > 0 {
+                return twoStarHotel.count
+            }
+            else { return 0 }
+        case .oneStar:
+            if oneStarHotel.count > 0 {
+                return oneStarHotel.count
+            }
+            else { return 0 }
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        if kind == UICollectionView.elementKindSectionHeader {
+            let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: headerIdentifier, for: indexPath) as! CollectionViewHeaderView
+            /// Check if it is the first section
+            if indexPath.section == 0 {
+                headerView.headerDividingLine.isHidden = true
+            }
+            else {
+                headerView.headerDividingLine.isHidden = false
+            }
+            headerView.sectionHeaderLabel.text = StarsForSection(rawValue: indexPath.section)?.headerTitle()
+            return headerView
+        }
+        return UICollectionReusableView()
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+        let section: StarsForSection = StarsForSection(rawValue: section)!
+        let headerSize = CGSize(width: UIScreen.main.bounds.width, height: 46)
+        let noHeader = CGSize(width: UIScreen.main.bounds.width, height: 0)
+        switch section {
+        case .fiveStars:
+            if fiveStarHotel.count > 0 { return headerSize }
+            else { return noHeader }
+        case .fourStars:
+            if fourStarHotel.count > 0 { return headerSize }
+            else { return noHeader }
+        case .threeStars:
+            if threeStarHotel.count > 0 { return headerSize }
+            else { return noHeader }
+        case .twoStars:
+            if twoStarHotel.count > 0 { return headerSize }
+            else { return noHeader }
+        case .oneStar:
+            if oneStarHotel.count > 0 { return headerSize }
+            else { return noHeader }
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let section: StarsForSection = StarsForSection(rawValue: indexPath.section)!
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as! HomeCollectionViewCell
-        let hotel = hotelsResult?[indexPath.row]
-        let viewModel = HomeViewModel()
-        viewModel.hotelResult = hotel
-        cell.hotelResult = hotel
+        
+        switch section {
+        case .fiveStars:
+            let hotel = fiveStarHotel[indexPath.row]
+            let viewModel = HomeViewModel()
+            viewModel.hotelResult = hotel
+            cell.hotelResult = hotel
+        case .fourStars:
+            let hotel = fourStarHotel[indexPath.row]
+            let viewModel = HomeViewModel()
+            viewModel.hotelResult = hotel
+            cell.hotelResult = hotel
+        case .threeStars:
+            let hotel = threeStarHotel[indexPath.row]
+            let viewModel = HomeViewModel()
+            viewModel.hotelResult = hotel
+            cell.hotelResult = hotel
+        case .twoStars:
+            let hotel = twoStarHotel[indexPath.row]
+            let viewModel = HomeViewModel()
+            viewModel.hotelResult = hotel
+            cell.hotelResult = hotel
+        case .oneStar:
+            let hotel = oneStarHotel[indexPath.row]
+            let viewModel = HomeViewModel()
+            viewModel.hotelResult = hotel
+            cell.hotelResult = hotel
+        }
         return cell
     }
 }

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/ViewModel/HomeViewModel.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/ViewModel/HomeViewModel.swift
@@ -1,0 +1,100 @@
+//
+//  HomeViewModel.swift
+//  Hurb_iOS_Challenge
+//
+//  Created by Gáudio Ney on 24/05/22.
+//
+
+import UIKit
+import SwiftUI
+import MapKit
+
+class HomeViewModel {
+    // MARK: - Properties
+    
+    /// Hotel Result
+    var hotelResult: HotelResult?
+    
+    var hotelsImage: [String] {
+        var imagesArray: [String] = []
+        guard let gallery = hotelResult?.gallery else { return [""] }
+        for image in gallery {
+            if var imageURL = image.url {
+                if !imageURL.contains("https:") {
+                    imageURL.insert("s", at: imageURL.index(imageURL.startIndex, offsetBy: 4))
+                }
+                imagesArray.append(imageURL)
+            }
+        }
+        return imagesArray
+    }
+    
+    var hotelDescriptionText: NSAttributedString {
+        let cityAddress = City.gramado.rawValue //hotelsResult?.address?.city?.gramado
+        let countryAddress = Country.brasil.rawValue //hotelsResult?.address?.country?.brasil
+        let text = NSMutableAttributedString(string: hotelResult?.name ?? "--",
+                                             attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .semibold)])
+        text.append(NSAttributedString(string: "・" + (cityAddress.capitalizedFirstLetter()) ,
+                                       attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .semibold)]))
+        text.append(NSAttributedString(string: ", " + (countryAddress.capitalizedFirstLetter()), attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .semibold)]))
+        return text
+    }
+    
+    var hotelFinalPriceText: NSAttributedString {
+        guard let hotelPrice = hotelResult?.price?.currentPrice else { return NSAttributedString(string: "--") }
+        guard let priceByNights = hotelResult?.price?.originalAmountPerDay else { return NSAttributedString(string: "--") }
+        let price = CurrencyUtils.formatPrice(price: hotelPrice)
+        var nights = 0
+        if (Int(priceByNights) != 0) {
+            nights = Int((Double(hotelPrice))/Double(priceByNights))
+        }
+        let text = NSMutableAttributedString(string: price,
+                                             attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .semibold)])
+        if nights > 0 {
+            text.append(NSAttributedString(string: " - \(String(nights))",
+                                           attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)]))
+            if nights > 1 {
+                text.append(NSAttributedString(string: " diárias",
+                                               attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)]))
+            }
+            else {
+                text.append(NSAttributedString(string: " diária",
+                                               attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)]))
+            }
+        }
+        
+        return text
+    }
+    
+    var hotelAmenitiesText: NSAttributedString {
+        guard let amenities = hotelResult?.amenities else { return NSAttributedString(string: "--") }
+        var amenityArray: [String] = []
+        
+        for amenity in amenities {
+            if let name = amenity.name {
+                amenityArray.append(name)
+            }
+        }
+        
+        let firt3Amenities = amenityArray.prefix(3)
+        
+        let text = NSMutableAttributedString(string: firt3Amenities[0],
+                                             attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)])
+        text.append(NSAttributedString(string: " - \(firt3Amenities[1])",
+                                       attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)]))
+        text.append(NSAttributedString(string: " - \(firt3Amenities[2])",
+                                       attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)]))
+        
+        return text
+    }
+    
+    var freeCancelingText: String {
+        if hotelResult?.huFreeCancellation ?? false {
+            return "Cancelamento gratuito"
+        }
+        else {
+            return ""
+        }
+    }
+    
+}

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/ViewModel/HomeViewModel.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/ViewModel/HomeViewModel.swift
@@ -113,8 +113,6 @@ class HomeViewModel {
     var hotelDetailSmallDescription: NSAttributedString {
         let text = NSMutableAttributedString(string: (hotelResult?.smallDescription ?? hotelResult?.resultDescription) ?? "--",
                                              attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .light)])
-        text.append(NSAttributedString(string: " ‣ Ver mais. ",
-                                       attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular), .foregroundColor: UIColor.hurbMainBlue]))
         return text
     }
     

--- a/Hurb_iOS_Challenge/Hurb_iOS_Challenge/ViewModel/HomeViewModel.swift
+++ b/Hurb_iOS_Challenge/Hurb_iOS_Challenge/ViewModel/HomeViewModel.swift
@@ -11,8 +11,9 @@ import MapKit
 
 class HomeViewModel {
     // MARK: - Properties
-    
-    /// Hotel Result
+    ///
+    /// Hotel Result: `Home`
+    ///
     var hotelResult: HotelResult?
     
     var hotelsImage: [String] {
@@ -33,36 +34,21 @@ class HomeViewModel {
         let cityAddress = City.gramado.rawValue //hotelsResult?.address?.city?.gramado
         let countryAddress = Country.brasil.rawValue //hotelsResult?.address?.country?.brasil
         let text = NSMutableAttributedString(string: hotelResult?.name ?? "--",
-                                             attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .semibold)])
+                                             attributes: [.font: UIFont.systemFont(ofSize: 14, weight: .regular)])
         text.append(NSAttributedString(string: "・" + (cityAddress.capitalizedFirstLetter()) ,
-                                       attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .semibold)]))
-        text.append(NSAttributedString(string: ", " + (countryAddress.capitalizedFirstLetter()), attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .semibold)]))
+                                       attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .regular)]))
+        text.append(NSAttributedString(string: ", " + (countryAddress.capitalizedFirstLetter()), attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .regular)]))
         return text
     }
     
     var hotelFinalPriceText: NSAttributedString {
-        guard let hotelPrice = hotelResult?.price?.currentPrice else { return NSAttributedString(string: "--") }
-        guard let priceByNights = hotelResult?.price?.originalAmountPerDay else { return NSAttributedString(string: "--") }
-        let price = CurrencyUtils.formatPrice(price: hotelPrice)
-        var nights = 0
-        if (Int(priceByNights) != 0) {
-            nights = Int((Double(hotelPrice))/Double(priceByNights))
-        }
+        guard let priceByNights = hotelResult?.price?.amountPerDay else { return NSAttributedString(string: "--") }
+        let price = CurrencyUtils.formatPrice(price: priceByNights)
+    
         let text = NSMutableAttributedString(string: price,
-                                             attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .semibold)])
-        if nights > 0 {
-            text.append(NSAttributedString(string: " - \(String(nights))",
-                                           attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)]))
-            if nights > 1 {
-                text.append(NSAttributedString(string: " diárias",
-                                               attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)]))
-            }
-            else {
-                text.append(NSAttributedString(string: " diária",
-                                               attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)]))
-            }
-        }
-        
+                                             attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .regular)])
+            text.append(NSAttributedString(string: " / noite",
+                                           attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .light)]))
         return text
     }
     
@@ -78,13 +64,23 @@ class HomeViewModel {
         
         let firt3Amenities = amenityArray.prefix(3)
         
-        let text = NSMutableAttributedString(string: firt3Amenities[0],
-                                             attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)])
-        text.append(NSAttributedString(string: " - \(firt3Amenities[1])",
-                                       attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)]))
-        text.append(NSAttributedString(string: " - \(firt3Amenities[2])",
-                                       attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular)]))
+        let text = NSMutableAttributedString(string: "✓ " + firt3Amenities[0],
+                                             attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .light)])
+        text.append(NSAttributedString(string: " ✓ \(firt3Amenities[1])",
+                                       attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .light)]))
+        text.append(NSAttributedString(string: " ✓ \(firt3Amenities[2])",
+                                       attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .light)]))
         
+        return text
+    }
+    
+    var hotelStars: String {
+        var text = ""
+        if let stars = hotelResult?.stars {
+            text = String(stars)
+            text += ".0"
+            text = "★ " + text
+        }
         return text
     }
     
@@ -97,4 +93,53 @@ class HomeViewModel {
         }
     }
     
+    ///
+    /// Hotel Result:  `Details`
+    ///
+    var hotelDetailName: String {
+        let text = hotelResult?.name ?? "--"
+        return text
+    }
+    
+    var hotelDetailLocation: NSAttributedString {
+        let cityAddress = City.gramado.rawValue //hotelsResult?.address?.city?.gramado
+        let countryAddress = Country.brasil.rawValue //hotelsResult?.address?.country?.brasil
+        let text = NSMutableAttributedString(string: "・ " + cityAddress.capitalizedFirstLetter(),
+                                             attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .regular)])
+        text.append(NSAttributedString(string: ", " + (countryAddress.capitalizedFirstLetter()), attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .regular)]))
+        return text
+    }
+    
+    var hotelDetailSmallDescription: NSAttributedString {
+        let text = NSMutableAttributedString(string: (hotelResult?.smallDescription ?? hotelResult?.resultDescription) ?? "--",
+                                             attributes: [.font: UIFont.systemFont(ofSize: 13, weight: .light)])
+        text.append(NSAttributedString(string: " ‣ Ver mais. ",
+                                       attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .regular), .foregroundColor: UIColor.hurbMainBlue]))
+        return text
+    }
+    
+    var hotelDetailFullDescription: String {
+        let text = hotelResult?.resultDescription ?? "--"
+        return text
+    }
+    
+    var hotelDetailAmenitiesText: NSAttributedString {
+        guard let amenities = hotelResult?.amenities else { return NSAttributedString(string: "--") }
+        var amenityArray: [String] = []
+        
+        for amenity in amenities {
+            if let name = amenity.name {
+                amenityArray.append(name)
+            }
+        }
+        
+        let text = NSMutableAttributedString(string: "Comodidades: \n",
+                                             attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .semibold)])
+        
+        for i in 0...(amenityArray.count - 1) {
+            text.append(NSAttributedString(string: " ✓ \(amenityArray[i])",
+                                           attributes: [.font: UIFont.systemFont(ofSize: 12, weight: .light)]))
+        }
+        return text
+    }
 }


### PR DESCRIPTION
## Implementation of Main Home and Hotels Details Page
- [x]  Hotels and Packages JSON files mocked.
- [x] FetchHotels service added.
- [x] Set the Home UI.
- [x] Set the Hotel Details UI.
- [x] Logic to filter the hotels by star values added.
- [x] Set the CollectionView Header UI.

### To do:
- [ ] Show the Request Log.
- [ ] Creat tests.
- [ ] Add packages section.
- [ ] Feature: favorite (favoritar).
- [ ] Feature: last seen (vistos por último).

## Screens Results

## Home

![Simulator Screen Shot - iPod touch (7th generation) - 2022-05-31 at 19 31 43](https://user-images.githubusercontent.com/62902650/171294966-62b177f9-bb19-4742-bb2a-74640bb0cdd3.png) ![Simulator Screen Shot - iPod touch (7th generation) - 2022-05-31 at 19 31 55](https://user-images.githubusercontent.com/62902650/171294987-7d7e653f-eb84-42b7-91ec-e525f4decd69.png)

## Hotel Details

![Simulator Screen Shot - iPod touch (7th generation) - 2022-05-31 at 19 32 06](https://user-images.githubusercontent.com/62902650/171295144-95cd36c7-0484-4855-bd31-825680415150.png) ![Simulator Screen Shot - iPod touch (7th generation) - 2022-05-31 at 19 32 16](https://user-images.githubusercontent.com/62902650/171295164-62728246-e8eb-4afb-93e4-6885aad1ae0f.png)

![Simulator Screen Shot - iPod touch (7th generation) - 2022-05-31 at 19 32 24](https://user-images.githubusercontent.com/62902650/171295195-6123d73e-b6fb-401f-933f-7f0301c6ade5.png) ![Simulator Screen Shot - iPod touch (7th generation) - 2022-05-31 at 19 32 33](https://user-images.githubusercontent.com/62902650/171295219-a3342582-db90-4e98-9237-0d422d12fae5.png)


